### PR TITLE
Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+.bundle

--- a/lib/librato-alerts.rb
+++ b/lib/librato-alerts.rb
@@ -13,28 +13,28 @@ module LibratoAlerts
   end
 
   def all
-    get("alerts")[:alerts]
+    request(method: :get)[:alerts]
   end
 
   def enable(alert_id)
-    put("alerts/#{alert_id}", active: true)
+    request(
+      endpoint: "/#{alert_id}",
+      method: :put,
+      active: true)
   end
 
   def disable(alert_id)
-    put("alerts/#{alert_id}", active: false)
+    request(
+      endpoint: "/#{alert_id}",
+      method: :put,
+      active: false)
+  end
+
   end
 
   private
 
-  def get(endpoint, parameters = {})
-    request(endpoint, :get, parameters)
-  end
-
-  def put(endpoint, parameters = {})
-    request(endpoint, :put, parameters)
-  end
-
-  def request(endpoint, method, parameters)
+  def request(endpoint: "", method:, **parameters)
     options = {
       method: method,
       params: default_parameters.merge(parameters),
@@ -44,7 +44,7 @@ module LibratoAlerts
       format: :json
     }
 
-    request = Nestful::Request.new("#{API_HOST}/#{endpoint}", options)
+    request = Nestful::Request.new("#{API_HOST}/alerts#{endpoint}", options)
 
     response = request.execute
 

--- a/librato-alerts.gemspec
+++ b/librato-alerts.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name                   = "librato-alerts"
-  spec.version                = "1.0.0"
-  spec.date                   = "2016-04-23"
+  spec.version                = "1.0.1"
+  spec.date                   = "2016-05-17"
   spec.summary                = "Interacts with Librato's Alerts API."
   spec.description            = "Interacts with Librato's Alerts API."
   spec.authors                = ["Juan Guerrero"]
@@ -13,6 +13,4 @@ Gem::Specification.new do |spec|
   spec.licenses               = ["MIT"]
 
   spec.add_runtime_dependency     "nestful"
-
-  spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
I've made a few changes to the library in order to support a pull-request I'll send soon that adds a feature to delete alerts. There were two approaches to refactor the code in order to avoid method name collision:

1.- Create a new `Client` class and move the request methods to it.
2.- Remove the request methods and just use the generic `#request`.

I prefer the latter way because it's simpler and I think it's an elegant way to solve the problem.
